### PR TITLE
Update EET-Compatibility-List.html

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -437,7 +437,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/Sampsca/ThrownHammers/releases">ThrownHammers</a> v6.0.1 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Tiax_for_BGII/releases">Tiax NPC for BGII</a> v5 or above</li>
 	<li><a href="https://www.gibberlings3.net/forums/topic/30797-unearthed-arcana-present-tome-blood-more-options-for-arcane-casters/">Tome and Blood</a> v0.72 or above</li>
-	<li><a href="http://forums.blackwyrmlair.net/index.php?s=00f34f09cedccbb2c3999b79dbe28215&showtopic=5221">Tower of Deception</a> v4.0.1 or above</li>
+	<li><a href="https://github.com/InfinityMods/TowerOfDeception/releases">Tower of Deception</a> v4.0.1 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/1251-trials-of-the-luremaster-for-bg2ee/">Trials of the Luremaster</a> v1.0 or above</li>
 	<li><a href="http://www.pocketplane.net/turnabout">Turnabout</a> vUpdatedForEE</li>
 	<li><a href="https://www.gibberlings3.net/mods/tweaks/tweaks/">Tweaks Anthology</a> v1 or later (previously known as BG2 Tweak Pack)</li>


### PR DESCRIPTION
Updated the link where latest version of the Tower of Deception mod can be downloaded. Previous link went to a forum post that linked to a 404.