### PR TITLE
Remove outdated The Calling install order suggestion.

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -461,7 +461,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/CrevsDaak/thalan">Thalantyr - Item Upgrade</a> v4.2.1 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/75663/kit-mod-the-artisans-kitpack">The Artisan's Kitpack</a> v1.7 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/beaurin/">The Beaurin Legacy</a> v3.6 or above</li>
-	<li><a href="https://www.gibberlings3.net/mods/quests/thecalling/">The Calling</a> IMPORTANT install after SCS or Tweaks Anthology but prior Sandrah, this way all mods automatically skip redundant components.</li>
+	<li><a href="https://www.gibberlings3.net/mods/quests/thecalling/">The Calling</a></li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/the-cowled-menace/">The Cowled Menace</a> v0.2.1 Beta or above</li>
 	<li><a href="https://github.com/BiGWorldProject/TDDz">The Darkest Day EE edition (TDDz)</a> v1.0 or above (please refer to the TDDz readme - this mod needs external resources from <a href="http://www.shsforums.net/files/file/323-the-darkest-day-v114/">original TDD</a>)</li>
 	<li><a href="https://github.com/K4thos/TGC1e">The Grey Clan Episode I: In Candlelight</a> v1.9 beta or above</li>


### PR DESCRIPTION
Beta 3 turned it into a quest mod with extra items, so it should be installed as a quest mod with extra items, not after SCS and Tweaks.