### PR TITLE
Improve text readability on high dpi screens

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -7,7 +7,7 @@
 <!--
 body  {
   font-family: Arial, Helvetica, sans-serif;
-  font-size: 12px;
+  font-size: 1rem;  /* formerly 12px */
   text-align: left;
   color: #000;
   background-color: #f2f2fc;
@@ -16,7 +16,6 @@ body  {
   }
 img {border : 0;}
 h1, h2, h3, h4, h5, h6 {
-  font-size: 17px;
   font-weight: bold;
   color: #0000cd;
   font-variant: small-caps;
@@ -36,11 +35,12 @@ h3, h4, h5, h6 {
   padding-left:5px;
   border-bottom:1px dotted #0000cd;
   }
-h2 {font-size : 16px;}
-h3 {font-size : 15px;}
-h4 {font-size : 14px;}
-h5 {font-size : 13px;}
-h6 {font-size : 12px;}
+h1 {font-size : 1.42rem;} /* formerly 17px */
+h2 {font-size : 1.33rem;} /* formerly 16px */
+h3 {font-size : 1.25rem;} /* formerly 15px */
+h4 {font-size : 1.17rem;} /* formerly 14px */
+h5 {font-size : 1.08rem;} /* formerly 13px */
+h6 {font-size : 1rem;}
 p, ul, table {clear:left;}
 a, a:link, a:visited, a:hover, a:active {
   color: #0012ff;


### PR DESCRIPTION
Text is difficult to read on high resolution screens without manual scaling.

This PR defines relative font size units in the embedded stylesheet section to render text more consistently on different screen resolutions.