### PR TITLE
Under-Respresented_Items points to latest release

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -488,7 +488,7 @@ a:hover.spoiler {
 	<li><a href="http://www.pocketplane.net/turnabout">Turnabout</a> vUpdatedForEE</li>
 	<li><a href="https://www.gibberlings3.net/mods/tweaks/tweaks/">Tweaks Anthology</a> v1 or later (previously known as BG2 Tweak Pack)</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/tyris/">Tyris Flare</a> v8</li>
-	<li><a href="https://www.gibberlings3.net/forums/topic/32757-weiduorg-under-represented-items-v7-released/?tab=comments#comment-295162">Under-Represented Items </a> v7 or above</li>
+	<li><a href="https://github.com/Pocket-Plane-Group/Under-Respresented_Items/releases">Under-Represented Items</a> v7 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/UnfinishedBusiness/releases">Unfinished Business</a> v27 RC1 or above</li>
 	<li><a href="https://github.com/Raduziel/Raduziels-Universal-Wizard-Spells/releases">Universal Wizard Spells</a> v2.5 or later</li>
 	<li><a href="https://forums.beamdog.com/discussion/56567/mod-bgii-ee-unofficial-item-pack">Unofficial Item Pack</a> v2.7b CAUTION: do not install "SoD items import" component in EET to avoid duplication!</li>


### PR DESCRIPTION
Under-Represented_Items was pointing to a post that pointed to an outdated version.  It now points to the latest github release, although the repo itself seems to be misspelled, @CamDawg.