### PR TITLE
Backend updates

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -157,7 +157,7 @@ a:hover.spoiler {
 
 <p>Installation tips and notes on compatibility</p>
 <ul>
-    <li>tools like <a href="https://forums.beamdog.com/discussion/74335/project-infinity-public-beta">Project Infinity</a> (successor of BWS) are the preferable ways to install mods for Windows users. Please read Project Infinity FAQ regarding EET installation instructions.</li>
+    <li>tools like <a href="https://forums.beamdog.com/discussion/74335/project-infinity-public-beta/p1">Project Infinity</a> (successor of BWS) are the preferable ways to install mods for Windows users. Please read Project Infinity FAQ regarding EET installation instructions.</li>
 	<li>it is highly recommended to check out the installation order and compatibility between mods. Just keep in mind that in EET game some BG1 mods need to be installed on BG:EE before EET installation on BG2:EE.</li>
 	<li>current compatibility between EET and other modifications are listed below.</li>
 	<li>note that versions of modifications below those stated are not compatible.</li>
@@ -184,7 +184,7 @@ a:hover.spoiler {
 
 <p>Here is a list of supported mods installed on BG:EE</p>
 <ul>
-	<li><a href="https://forums.beamdog.com/discussion/38824/aerie-in-bg-ee-v1-1">Aerie for BG:EE</a> v1.1 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/38824/aerie-in-bg-ee-v1-1/p1">Aerie for BG:EE</a> v1.1 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/bg1ub/releases">BG1 Unfinished Business</a> v14 [BETA] or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/18833/bg-ee-dark-horizons-released/p1">Dark Horizons BG:EE</a> v2.12 or above</li>
 	<li><a href="https://github.com/ArtemiusI/Drake/releases">Drake NPC</a> v0.1 BETA</li>
@@ -196,7 +196,7 @@ a:hover.spoiler {
 	<li><a href="http://www.shsforums.net/files/file/1164-sharteel-npc-mod-for-sod/">Sharteel NPC mod for SoD</a> Pre-Release 1.1 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/42721/npc-mod-sirene-npc-for-bg-ee-v1-0/p1">Sirene NPC</a> v1.0 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/33291/tenya-thermidor-v1-3/p1">Tenya Thermidor</a> v1.5 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/42168/mod-the-stone-of-askavar-for-totsc-tutu-bgt-and-bg-ee">The Stone of Askavar</a> v1.9 or above (select default option during installation - despite the name it's compatible with both EET Worldmap and BP-BGT Worldmap)</li>
+	<li><a href="https://forums.beamdog.com/discussion/42168/mod-the-stone-of-askavar-for-totsc-tutu-bgt-and-bg-ee/p1">The Stone of Askavar</a> v1.9 or above (select default option during installation - despite the name it's compatible with both EET Worldmap and BP-BGT Worldmap)</li>
 	<li><a href="https://forums.beamdog.com/discussion/15959/mod-twas-a-slow-boat-from-kara-tur-queststorenew-items-release-90/p1">T'was a Slow Boat from Kara-Tur</a> v.90 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/verrsza-bg1ee/">Verr'Sza NPC</a> v2.4 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/white-npc/">White NPC</a> v2.2 or above</li>
@@ -230,7 +230,7 @@ a:hover.spoiler {
 	<li><a href="https://www.gibberlings3.net/files/file/687-anishai-one-day-npc/">Anishai One Day NPC</a> v2 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/g3a/">Anniversary (G3 mini mod)</a> v9.1</li>
 	<li><a href="http://www.shsforums.net/files/file/1001-arath/">Arath</a> v4 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/51904/mod-artaport-4-0">Artaport</a> (EE native version of <a href="http://www.shsforums.net/files/file/1033-paintbg/"> PaintBG)</a> v2 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/51904/mod-artaport-4-0/p1">Artaport</a> (EE native version of <a href="http://www.shsforums.net/files/file/1033-paintbg/"> PaintBG)</a> v2 or above</li>
 	<li><a href="https://github.com/Gitjas/ACBre/releases/latest">Ascalon's Breagar</a> v7.0 or above</li>
 	<li><a href="https://github.com/Gitjas/Ascalons_Questpack/releases">Ascalon's Questpack</a> v2.02 or above</li>
 	<li><a href="https://github.com/InfinityMods/Ascension">Ascension</a> v1.5 BETA or above</li>
@@ -259,7 +259,7 @@ a:hover.spoiler {
 	<li><a href="http://www.baldursgatemods.com/forums/index.php?topic=7697.0">BG1 NPCs for SoA &amp; ToB</a> v10 and above</li>
 	<li><a href="http://www.shsforums.net/topic/55573-bg-ee-classic-movies/">BG:EE Classic Movies</a> v2.3.0 or above (install after EEUITweaks User Interface Mods Collection)</li>
 	<li><a href="https://github.com/AstroBryGuy/BGEESpawn">BGEE Leveled Spawns Mod</a> v0.4 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/58941/mod-bgeenpc-tweaks-for-bgee-sod-bg2ee-eet/">BGEENPC Tweaks for BGEE / SOD / BG2EE / EET</a> v1.0 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/58941/mod-bgeenpc-tweaks-for-bgee-sod-bg2ee-eet/p1">BGEENPC Tweaks for BGEE / SOD / BG2EE / EET</a> v1.0 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/772-bolsa/">Bolsa Merchant</a> v6.0.0 or above</li>
 	<li><a href="https://www.baldurs-gate.de/index.php?resources/brages-redemption.42/">Brage's Redemption Mod</a> v0.1 or above</li>
 	<li><a href="https://baldurs-gate.de/index.php?resources/brandock-der-magier.48/">Brandock the Mage NPC Mod</a> vBeta1 or above</li>
@@ -297,7 +297,7 @@ a:hover.spoiler {
 	<li><a href="https://www.gibberlings3.net/mods/kits/cleric/">Divine Remix</a> for now, please use <a href="https://github.com/Gibberlings3/Divine_Remix/archive/master.zip">latest Github version</a></li>
 	<li><a href="https://github.com/trinit2/Bg2Dorn/">Dorn Romance (SoA+ToB)</a>v3.2 or above</li>
 	<li><a href="https://github.com/thisisulb/DreamWalkerShamanKit">Dream Walker - a Shaman Kit</a> v1.2 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/62981/mod-druid-grove-makeover">Druid Grove Makeover</a> v1 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/62981/mod-druid-grove-makeover/p1">Druid Grove Makeover</a> v1 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Dungeon_Crawl/releases">Dungeon Crawl</a> v11 or above</li>
 	<li><a href="https://www.pocketplane.net/dungeon-be-gone/">Dungeon-Be-Gone</a> v1.7</li>
 	<li><a href="https://github.com/SpellholdStudios/Edwin_Romance/releases/latest">Edwin Romance</a> v2.08 or above</li>
@@ -308,10 +308,10 @@ a:hover.spoiler {
 	<li><a href="https://www.gibberlings3.net/mods/tweaks/enemy_randomizer/">Enemy Randomizer</a> v1 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/other/endlessbg1/">Endless BG1</a> v1 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/other/enhanced-powergaming-scripts/">Enhanced Powergaming Scripts</a> v1.0 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/74158/mod-epic-thieving-more-benefits-from-high-thieving-skills">Epic Thieving</a> v2.6 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/74158/mod-epic-thieving-more-benefits-from-high-thieving-skills/p1">Epic Thieving</a> v2.6 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/evandra/">Evandra</a> v1.0 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/cliffette/">Every Mod and Dog (Mini-quests)</a> v8</li>
-	<li><a href="https://forums.beamdog.com/discussion/73749">Extra Expanded Enhanced Encounters!</a> v2.0 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/73749/extra-expanded-enhanced-encounters-module-download/p1">Extra Expanded Enhanced Encounters!</a> v2.0 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/1083-fade/">Fade</a> v5.1 (experimental) or above</li>
 	<li><a href="https://github.com/SpellholdStudios/Fading_Promises/releases">Fading Promises</a> v8 or above</li>
 	<li><a href="https://github.com/UnearthedArcana/Faiths_and_Powers/releases">Faiths and Powers (kitpack and divine caster/spell tweaks)</a> v0.74g or above</li>
@@ -324,7 +324,7 @@ a:hover.spoiler {
 	<li><a href="https://www.gibberlings3.net/mods/npcs/gavin-bg2/">Gavin BG2 NPC</a> v22 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/glam-npc-pack/">Glam's BGEE NPC Pack (Littlun Plunkett, Vynd, Moidre, Dave, Flara)</a> v1 or above</li>
 	<li><a href="http://www.shsforums.net/topic/58696-mod-golem-construction-for-spellcasters/">Golem Construction for Spellcasters</a> v2.0 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/82008">Graion's Soundsets</a> (BG1 and BG2 sets are redundant for EET)</li>
+	<li><a href="https://forums.beamdog.com/discussion/82008/graions-soundsets-pst-iwd-iwd2-bg-bg2-bgnpc-30-for-bg-sod-bg2-iwd-eet-ee-2-6/p1">Graion's Soundsets</a> (BG1 and BG2 sets are redundant for EET)</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/grey-the-dog/">Grey the Dog</a> v1.0 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/HaerdalisFriendship/releases">Haer'Dalis Friendship</a> v1 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/984-haerdalis-romance/">Haer'Dalis Romance</a> v2.2</li>
@@ -361,13 +361,13 @@ a:hover.spoiler {
 	<li><a href="http://www.shsforums.net/files/file/801-jans-alchemy/">Jan's Alchemy</a> v8.0.0 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/tweaks/jasteys-sod-tweak-pack/">Jastey's SoD Tweakpack</a> v1.0 or above</li>
 	<li><a href="https://www.gibberlings3.net/forums/topic/32227-bwl-jini-romance-mod-update/?tab=comments#comment-290238">Jini Romance</a> v3.1 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/18607/jkits-v7-kenshei-undead-eliminator-amazon-3-20-18">JKits (Kenshei, Undead Eliminator, Amazon)</a> v7 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/18607/jkits-v7-kenshei-undead-eliminator-amazon-3-20-18/p1">JKits (Kenshei, Undead Eliminator, Amazon)</a> v7 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/74630/v1-6-kale-a-halfling-barbarian-for-bg-ee-sod-and-eet/p1">Kale NPC</a> v1.6 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/keldorn/">Keldorn Romance (berelinde's)</a> v1.0 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Kelsey/releases">Kelsey NPC</a> v5 or above</li>
 	<li><a href="https://www.pocketplane.net/keto-npc/">Keto NPC</a> v5 or above</li>
 	<li><a href="https://www.gibberlings3.net/files/file/702-a-mod-for-the-orderly/">Keyring: A Mod for the Orderly</a> v7.0 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/79293/mod-kit-le-rodeur-de-lombre-shadow-ranger-updated">Kit Le Rôdeur de l'ombre (Shadow Ranger)</a> v1.2 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/79293/mod-kit-le-rodeur-de-lombre-shadow-ranger-updated/p1">Kit Le Rôdeur de l'ombre (Shadow Ranger)</a> v1.2 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/kivan/">Kivan and Deheriana Companions for BG2</a> v16</li>
 	<li><a href="https://github.com/SpellholdStudios/KorganFriendship/releases">Korgan Friendship</a> V1.0 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/KorgansRedemption/releases">Korgan's Redemption</a> v10.0.1 or above</li>
@@ -384,7 +384,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/Raduziel/MilitiaOfficer-Kit">Militia Officer (Kit for PC or Khalid)</a> v1.3 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/MinscFriendship/releases">Minsc Friendship</a> v1.0 or above</li>
 	<li><a href="https://github.com/aquadrizzt/MonasticOrders/releases">Monastic Orders of Faerun</a> v0.42 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/18108/item-mod-more-style-for-mages-ranged-wizards-staffs-circlets-robe-visual-tweaks-now-in-iwd-ee">More Styles for Mages</a> v1.55 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/18108/item-mod-more-style-for-mages-ranged-wizards-staffs-circlets-robe-visual-tweaks-now-in-iwd-ee/p1">More Styles for Mages</a> v1.55 or above</li>
 	<li><a href="https://github.com/CrevsDaak/m7multikit">Multiclassed Multikit Builder Mod</a> v0.27.3 or above</li>
 	<li><a href="https://github.com/lzenner/mptweaks/releases/latest">Multiplayer Tweaks</a></li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/murneth/">Mur'Neth NPC mod</a> v12 or above</li>
@@ -458,7 +458,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/Gibberlings3/SwordCoastStratagems/releases">Sword Coast Stratagems</a> v32 RC5 or above</li>
 	<li><a href="https://github.com/Argent77/A7-TestYourMettle/releases">Test Your Mettle!</a> v0.1-beta or above</li>
 	<li><a href="https://github.com/CrevsDaak/thalan">Thalantyr - Item Upgrade</a> v4.2.1 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/75663/kit-mod-the-artisans-kitpack">The Artisan's Kitpack</a> v1.7 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/75663/kit-mod-the-artisans-kitpack/p1">The Artisan's Kitpack</a> v1.7 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/beaurin/">The Beaurin Legacy</a> v3.6 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/thecalling/">The Calling</a></li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/the-cowled-menace/">The Cowled Menace</a> v0.2.1 Beta or above</li>
@@ -488,7 +488,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/Pocket-Plane-Group/Under-Respresented_Items/releases">Under-Represented Items</a> v7 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/UnfinishedBusiness/releases">Unfinished Business</a> v27 RC1 or above</li>
 	<li><a href="https://github.com/Raduziel/Raduziels-Universal-Wizard-Spells/releases">Universal Wizard Spells</a> v2.5 or later</li>
-	<li><a href="https://forums.beamdog.com/discussion/56567/mod-bgii-ee-unofficial-item-pack">Unofficial Item Pack</a> v2.7b CAUTION: do not install "SoD items import" component in EET to avoid duplication!</li>
+	<li><a href="https://forums.beamdog.com/discussion/56567/mod-bgii-ee-unofficial-item-pack/p1">Unofficial Item Pack</a> v2.7b CAUTION: do not install "SoD items import" component in EET to avoid duplication!</li>
 	<li><a href="http://www.shsforums.net/files/file/1041-valerie/">Valerie NPC for Baldur's Gate I</a> v1.2 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/ValygarFriendship/releases">Valygar Friendship</a> v1.0</li>
 	<li><a href="http://www.shsforums.net/files/file/1195-vampire-world-for-eet/">Vampire World</a> v0.42 or above CAUTION mod is still experimental according to author</li>	
@@ -496,8 +496,8 @@ a:hover.spoiler {
 	<li><a href="https://github.com/SpellholdStudios/ViconiaFriendship/releases">Viconia Friendship</a> v4.3</li>
 	<li><a href="http://www.shsforums.net/files/file/882-viconia-revamped/">Viconia Revamped</a> v6.0</li>
 	<li><a href="https://forums.beamdog.com/discussion/74701/v1-57-vienxay-a-elven-shadowmage-npc-for-bg-ee-sod-and-eet/p1">Vienxay NPC</a> v1.57 or above</li>
-	<li><a href="https://forums.beamdog.com/discussion/69177/v0-1-warlock-mod">Warlock kit</a></li>
-	<li><a href="https://forums.beamdog.com/discussion/64119/kit-rework-way-of-the-assassin-v1-1">Way of the Assassin</a></li>
+	<li><a href="https://forums.beamdog.com/discussion/69177/v0-1-warlock-mod/p1">Warlock kit</a></li>
+	<li><a href="https://forums.beamdog.com/discussion/64119/kit-rework-way-of-the-assassin-v1-1/p1">Way of the Assassin</a></li>
 	<li><a href="https://downloads.weaselmods.net/download/weasels/">Weasels!</a> v1.2 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/wheels/">Wheels of Prophecy</a> v6 or above</li>
 	<li><a href="https://github.com/BGforgeNet/bg2-wildmage">Wild Mage Additions</a> v2.3 beta or above</li>

--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -199,7 +199,7 @@ a:hover.spoiler {
 	<li><a href="http://www.shsforums.net/files/file/1164-sharteel-npc-mod-for-sod/">Sharteel NPC mod for SoD</a> Pre-Release 1.1 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/42721/npc-mod-sirene-npc-for-bg-ee-v1-0/p1">Sirene NPC</a> v1.0 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/33291/tenya-thermidor-v1-3/p1">Tenya Thermidor</a> v1.5 or above</li>
-	<li><a href="http://forums.beamdog.com/discussion/42168/mod-the-stone-of-askavar-for-totsc-tutu-bgt-and-bg-ee">The Stone of Askavar</a> v1.9 or above (select default option during installation - despite the name it's compatible with both EET Worldmap and BP-BGT Worldmap)</li>
+	<li><a href="https://forums.beamdog.com/discussion/42168/mod-the-stone-of-askavar-for-totsc-tutu-bgt-and-bg-ee">The Stone of Askavar</a> v1.9 or above (select default option during installation - despite the name it's compatible with both EET Worldmap and BP-BGT Worldmap)</li>
 	<li><a href="https://forums.beamdog.com/discussion/15959/mod-twas-a-slow-boat-from-kara-tur-queststorenew-items-release-90/p1">T'was a Slow Boat from Kara-Tur</a> v.90 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/verrsza-bg1ee/">Verr'Sza NPC</a> v2.4 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/white-npc/">White NPC</a> v2.2 or above</li>
@@ -226,7 +226,7 @@ a:hover.spoiler {
 	<li><a href="https://www.baldurs-gate.de/index.php?resources/jasteys-ajantis-bg1-expansion.2/">Ajantis BG1 Expansion</a> v10 or above</li>
 	<li><a href="http://www.shsforums.net/topic/59054-ajocmod-for-ee-and-eet/">Ajoc's minimod for EE and EET</a> v1.0 or above (this update requires resources from <a href="http://www.shsforums.net/files/file/119-ajocs-minimod/">original ajocmod</a>)</li>
 	<li><a href="http://www.shsforums.net/files/file/1053-almaterias-restoration-project/">Almateria's Restoration Project</a> v8.2.7 or above</li>
-	<li><a href="http://www.gibberlings3.net/alternatives/">Alternatives</a> v12 or above</li>
+	<li><a href="https://www.gibberlings3.net/mods/quests/alternatives/">Alternatives</a> v12 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/amber/">Amber</a> v5 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/angelo/">Angelo NPC</a> v6</li>
 	<li><a href="https://github.com/thisisulb/AnimalCompanions">Animal Companions</a> v1.3 or above</li>
@@ -236,7 +236,7 @@ a:hover.spoiler {
 	<li><a href="https://forums.beamdog.com/discussion/51904/mod-artaport-4-0">Artaport</a> (EE native version of <a href="http://www.shsforums.net/files/file/1033-paintbg/"> PaintBG)</a> v2 or above</li>
 	<li><a href="https://github.com/Gitjas/ACBre/releases/latest">Ascalon's Breagar</a> v7.0 or above</li>
 	<li><a href="https://github.com/Gitjas/Ascalons_Questpack/releases">Ascalon's Questpack</a> v2.02 or above</li>
-	<li><a href="https://github.com/BiGWorldProject/Ascension">Ascension</a> v1.5 BETA or above</li>
+	<li><a href="https://github.com/InfinityMods/Ascension">Ascension</a> v1.5 BETA or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Assassinations/releases">Assassinations</a> v13 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/oozes-lounge/">Athkatlan Grounds: Ooze's Lounge</a> v2.3 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/southern-edge/">Athkatlan Grounds: Southern Edge</a> v1.0 or above</li>
@@ -253,7 +253,7 @@ a:hover.spoiler {
 	<li><a href="http://www.shsforums.net/files/file/1216-bank-of-baldurs-gate-for-eet/">Bank of Baldur's Gate</a></li>
 	<li><a href="https://github.com/Argent77/A7-BanterAccelerator/releases">Banter Accelerator for Enhanced Edition games</a> v1.0 or later</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Banter_Pack/releases">Banter Packs</a> v15 or above</li>
-	<li><a href="http://github.com/ArtemiusI/Bardic-Wonders">Bardic-Wonders</a></li>
+	<li><a href="https://github.com/ArtemiusI/Bardic-Wonders">Bardic-Wonders</a></li>
 	<li><a href="https://www.gibberlings3.net/mods/tweaks/appraisal/">Bardic Appraisal</a></li>
 	<li><a href="https://github.com/thisisulb/BearWalkerKit">Bear Walker - a Werebear / Ranger Kit</a> v3.0 or above</li>
 	<li><a href="https://github.com/D2-mods/Better-IWD-Pregen/releases">Better IWD Pregen - a minimalist script for all classes</a> v0.6 or above</li>
@@ -302,7 +302,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/thisisulb/DreamWalkerShamanKit">Dream Walker - a Shaman Kit</a> v1.2 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/62981/mod-druid-grove-makeover">Druid Grove Makeover</a> v1 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Dungeon_Crawl/releases">Dungeon Crawl</a> v11 or above</li>
-	<li><a href="http://www.pocketplane.net/dbg">Dungeon-Be-Gone</a> v1.7</li>
+	<li><a href="https://www.pocketplane.net/dungeon-be-gone/">Dungeon-Be-Gone</a> v1.7</li>
 	<li><a href="https://github.com/SpellholdStudios/Edwin_Romance/releases/latest">Edwin Romance</a> v2.08 or above</li>
 	<li><a href="https://github.com/K4thos/EET_Tweaks/releases/latest">EET Tweaks</a> v1.0 or above</li>
 	<li><a href="https://www.gibberlings3.net/forums/topic/30832-ui-eeuitweaks-mod-collection-all-ees/">EEUITweaks User Interface Mods Collection</a> v1.5 or above (can be installed even after setup-EET_end)</li>
@@ -319,9 +319,9 @@ a:hover.spoiler {
 	<li><a href="https://github.com/SpellholdStudios/Fading_Promises/releases">Fading Promises</a> v8 or above</li>
 	<li><a href="https://github.com/UnearthedArcana/Faiths_and_Powers/releases">Faiths and Powers (kitpack and divine caster/spell tweaks)</a> v0.74g or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Finch_NPC/releases">Finch NPC mod</a> v5 or above</li>
-	<li><a href="https://github.com/BiGWorldProject/FishingForTrouble">Fishing For Trouble</a> v3.1 pre-release or above</li>
+	<li><a href="https://github.com/InfinityMods/FishingForTrouble">Fishing For Trouble</a> v3.1 pre-release or above</li>
 	<li><a href="https://github.com/CrevsDaak/m7multikit">FlameWing's Multikit mod</a> v0.27.3</li>
-	<li><a href="https://github.com/lzenner/framed/releases/latest">Framed</a> alternative chapter 6</li>
+	<li><a href="https://github.com/Gibberlings3/framed/releases">Framed</a> alternative chapter 6</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/garrick/">Garrick's Infatuation</a> vBeta 4 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/gavin/">Gavin BG1 NPC</a> v12 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/gavin-bg2/">Gavin BG2 NPC</a> v22 or above</li>
@@ -368,7 +368,7 @@ a:hover.spoiler {
 	<li><a href="https://forums.beamdog.com/discussion/74630/v1-6-kale-a-halfling-barbarian-for-bg-ee-sod-and-eet/p1">Kale NPC</a> v1.6 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/keldorn/">Keldorn Romance (berelinde's)</a> v1.0 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Kelsey/releases">Kelsey NPC</a> v5 or above</li>
-	<li><a href="http://www.pocketplane.net/keto">Keto NPC</a> v5 or above</li>
+	<li><a href="https://www.pocketplane.net/keto-npc/">Keto NPC</a> v5 or above</li>
 	<li><a href="https://www.gibberlings3.net/files/file/702-a-mod-for-the-orderly/">Keyring: A Mod for the Orderly</a> v7.0 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/79293/mod-kit-le-rodeur-de-lombre-shadow-ranger-updated">Kit Le Rôdeur de l'ombre (Shadow Ranger)</a> v1.2 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/kivan/">Kivan and Deheriana Companions for BG2</a> v16</li>
@@ -384,10 +384,10 @@ a:hover.spoiler {
 	<li><a href="https://github.com/SpellholdStudios/MazzyFriendship/releases">Mazzy Friendship</a> v3.2 or above</li>
 	<li><a href="https://github.com/Raduziel/Mercenary-Kit/releases">Mercenary (Fighter Kit for PC or Kagain)</a> v2.4 or above</li>
 	<li><a href="https://github.com/UnearthedArcana/Might_and_Guile/releases">Might and Guile (a tweak mod and kit pack for warriors and rogues)</a> v2.1 or above</li>
-	<li><a href="https://github.com/Raduziel/MilitiaOfficer-Kit.git">Militia Officer (Kit for PC or Khalid)</a> v1.3 or above</li>
+	<li><a href="https://github.com/Raduziel/MilitiaOfficer-Kit">Militia Officer (Kit for PC or Khalid)</a> v1.3 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/MinscFriendship/releases">Minsc Friendship</a> v1.0 or above</li>
 	<li><a href="https://github.com/aquadrizzt/MonasticOrders/releases">Monastic Orders of Faerun</a> v0.42 or above</li>
-	<li><a href="http://forums.beamdog.com/discussion/18108/item-mod-more-style-for-mages-ranged-wizards-staffs-circlets-robe-visual-tweaks-now-in-iwd-ee">More Styles for Mages</a> v1.55 or above</li>
+	<li><a href="https://forums.beamdog.com/discussion/18108/item-mod-more-style-for-mages-ranged-wizards-staffs-circlets-robe-visual-tweaks-now-in-iwd-ee">More Styles for Mages</a> v1.55 or above</li>
 	<li><a href="https://github.com/CrevsDaak/m7multikit">Multiclassed Multikit Builder Mod</a> v0.27.3 or above</li>
 	<li><a href="https://github.com/lzenner/mptweaks/releases/latest">Multiplayer Tweaks</a></li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/murneth/">Mur'Neth NPC mod</a> v12 or above</li>
@@ -400,9 +400,9 @@ a:hover.spoiler {
 	<li><a href="https://github.com/SpellholdStudios/NTotSC/releases/latest">Northern Tales of the Sword Coast (NTotSC)</a> v2.1 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/NPC_Flirt_Packs/releases">NPC Flirt Packs</a> v1.04 or above</li>
 	<li><a href="https://github.com/Argent77/A7-NPCGenerator/releases">NPC Generator</a> v1.0 or above</li>
-	<li><a href="https://www.gibberlings3.net/mods/tweaks/npckit/">NPC Kitpack</a> v5</li>
+	<li><a href="https://www.gibberlings3.net/mods/kits/npckit/">NPC Kitpack</a> v5</li>
 	<li><a href="https://www.gibberlings3.net/mods/tweaks/npctweak/">NPC Tweak</a> v6</li>
-	<li><a href="https://github.com/subtledoctor/NPC_EE/releases">NPC_EE</a> v2.3 or above</li>
+	<li><a href="https://github.com/UnearthedArcana/NPC_EE/releases">NPC_EE</a> v2.3 or above</li>
 	<li><a href="https://github.com/thisisulb/NoSoDSound">NPCs keep BG1 sound sets during SoD</a> v1 or above</li>
 	<li><a href="https://github.com/ArtemiusI/Pai-Na-NPC-mod-for-BG2-EE/releases">Pai'Na NPC for BG2:EE</a> v1.2 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/1032-paintbg-for-bgee/">PaintBG for BG:EE</a> v2.1</li>
@@ -412,12 +412,12 @@ a:hover.spoiler {
 	<li><a href="https://github.com/4Luke4/PnP-Potions/releases">PnP Potions</a> v1.2.2 or above</li>
 	<li><a href="https://github.com/DaftHunk/Portraits-Portraits-Everywhere/">Portraits Portraits Everywhere</a> v1.01 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/quayle-bg2/">Quayle BG2</a> v6.2 or above</li>
-	<li><a href="http://www.pocketplane.net/quest">Quest Pack</a> v3.3</li>
+	<li><a href="https://www.pocketplane.net/quest-pack/">Quest Pack</a> v3.3</li>
 	<li><a href="https://forums.beamdog.com/discussion/71473/megamod-2-86-mazzy-romance-clara-npc-darkside-anomen-flying-aerie-for-the-evil-more/p1">Ratatoskr and BCaesar's Multi-Mod: All Things Mazzy, Clara (Human Hexxat) NPC, Darkside Anomen, and more</a> v1.038 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/1079-recolored-toolbar-buttons-for-bgee-bg2ee/">Recolored toolbar buttons for BG:EE &amp; BG2:EE</a> v4.1 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/77784/v1-37-recorder-a-gnome-lorekeeper-npc-for-bg-ee-sod-and-eet/p1">Recorder NPC</a> v1.37 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/Red_Dragon_Summoning_Spell">Red Dragon Summoning</a> v2.0.0 or above</li>
-	<li><a href="https://github.com/subtledoctor/refinements/releases">Refinements</a> v4 RC8 or above (only HLA and kit components have been updated to work with EE platforms)</li>
+	<li><a href="https://github.com/UnearthedArcana/refinements/releases">Refinements</a> v4 RC8 or above (only HLA and kit components have been updated to work with EE platforms)</li>
 	<li><a href="https://github.com/SpellholdStudios/Region_of_Terror/releases/latest">Region of Terror</a> v3.1 or above</li>
 	<li><a href="https://github.com/Raduziel/Relieve-Wizard-Slayer/releases">Relieve Wizard Slayer</a> (must be installed after Wizard Slayer Rebalancing)</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Reunion/releases">Reunion</a> v4 or above</li>
@@ -434,7 +434,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/SpellholdStudios/SarevokFriendship/releases">Sarevok Friendship</a> v2.3</li>
 	<li><a href="http://www.shsforums.net/files/file/1110-sarevok-related-tweaks/">Sarevok related tweaks</a> v1.2 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/810-sarevok-romance/">Sarevok Romance</a> v1.3</li>
-	<li><a href="https://github.com/subtledoctor/Scales_of_Balance/releases">Scales of Balance</a> v5.1 or above</li>
+	<li><a href="https://github.com/UnearthedArcana/Scales_of_Balance/releases">Scales of Balance</a> v5.1 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/shades-of-the-sword-coast/">Shades of the Sword Coast</a> v6 or above</li>
 	<li><a href="https://github.com/ArtemiusI/Shadow-Magic/">Shadow Magic</a> v1.85 or later</li>
 	<li><a href="https://github.com/SpellholdStudios/Shadows_over_Soubar/releases">Shadows Over Soubar</a> v1.14 or above</li>
@@ -465,12 +465,12 @@ a:hover.spoiler {
 	<li><a href="https://www.gibberlings3.net/mods/npcs/beaurin/">The Beaurin Legacy</a> v3.6 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/thecalling/">The Calling</a></li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/the-cowled-menace/">The Cowled Menace</a> v0.2.1 Beta or above</li>
-	<li><a href="https://github.com/BiGWorldProject/TDDz">The Darkest Day EE edition (TDDz)</a> v1.0 or above (please refer to the TDDz readme - this mod needs external resources from <a href="http://www.shsforums.net/files/file/323-the-darkest-day-v114/">original TDD</a>)</li>
+	<li><a href="https://github.com/InfinityMods/TDDz">The Darkest Day EE edition (TDDz)</a> v1.0 or above (please refer to the TDDz readme - this mod needs external resources from <a href="http://www.shsforums.net/files/file/323-the-darkest-day-v114/">original TDD</a>)</li>
 	<li><a href="https://github.com/K4thos/TGC1e">The Grey Clan Episode I: In Candlelight</a> v1.9 beta or above</li>
 	<li><a href="http://www.shsforums.net/files/file/1159-the-horde-beta/">The Horde</a> v1.2 beta or above</li>
 	<li><a href="http://www.shsforums.net/files/file/38-jerry-zinger-show/">The Jerry Zinger Show</a> v5.0 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/39-longer-road/">The Longer Road</a> v2.0.1 or above</li>
-	<li><a href="http://www.pocketplane.net/tutumods">The Lure of the Sirine's Call</a> v15 or above</li>
+	<li><a href="https://www.pocketplane.net/bg1tutu-enhancements/">The Lure of the Sirine's Call</a> v15 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/The_Minotaur_and_Lilacor/releases">The Minotaur and Lilacor</a> v1.6</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Sellswords/releases">The Sellswords</a> v7 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/151-the-slithering-menace-tob/">The Slithering Menace</a> v4.0.0 or above</li>
@@ -485,7 +485,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/InfinityMods/TowerOfDeception/releases">Tower of Deception</a> v4.0.1 or above</li>
 	<li><a href="https://github.com/Gibberlings3/transitions/releases/latest">Transitions</a></li>
 	<li><a href="http://www.shsforums.net/files/file/1251-trials-of-the-luremaster-for-bg2ee/">Trials of the Luremaster</a> v1.0 or above</li>
-	<li><a href="http://www.pocketplane.net/turnabout">Turnabout</a> vUpdatedForEE</li>
+	<li><a href="https://www.pocketplane.net/turnabout/">Turnabout</a> vUpdatedForEE</li>
 	<li><a href="https://www.gibberlings3.net/mods/tweaks/tweaks/">Tweaks Anthology</a> v1 or later (previously known as BG2 Tweak Pack)</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/tyris/">Tyris Flare</a> v8</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Under-Respresented_Items/releases">Under-Represented Items</a> v7 or above</li>
@@ -510,7 +510,7 @@ a:hover.spoiler {
 	<li><a href="http://www.shsforums.net/files/file/960-wizard-slayer-rebalancing-v113-windows-version/">Wizard Slayer Rebalancing</a> v1.14 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/BP-BGT-Worldmap/releases">Worldmap</a> v10.2.3 or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Xan_for_BGII/releases">Xan for BG2</a> v17 or above</li>
-	<li><a href="http://www.pocketplane.net/tutumods">Xan's BG1 friendship path</a> v10 or above</li>
+	<li><a href="https://www.pocketplane.net/bg1tutu-enhancements/">Xan's BG1 friendship path</a> v10 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/710-xulaye/">Xulaye NPC</a> v2.0 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/Yeslick_NPC/releases">Yeslick SoA/ToB</a> v2.0 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/YoshimoFriendship/releases">Yoshimo Friendship</a> v4.3 or above</li>

--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
 <title>Mod Compatibility List for EET</title>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
@@ -168,7 +168,7 @@ a:hover.spoiler {
 </ul>
 </div>
 
-<!-- ================== T a b l e ================== --><a id="table" name="Table of Contents"></a>
+<!-- ================== T a b l e ================== --><div><a id="table" name="table"></a></div>
 <h2>Table of Contents</h2>
 <div class="section">
 	<ol>
@@ -177,7 +177,7 @@ a:hover.spoiler {
 	</ol>
 </div>
 
-<!-- ================== BGEE ================== --><a id="bgee" name="bgee"></a>
+<!-- ================== BGEE ================== --><div><a id="bgee" name="bgee"></a></div>
 <h2>Mods installed on BG:EE previous to installing EET on BG2:EE</h2>
 <div class="section">
 
@@ -210,7 +210,7 @@ a:hover.spoiler {
 <p>Mods have been tested with versions mentioned in above list. It's unlikely that newer ones will break something, as the compatibility changes made to them during EET installation are minimal, if made at all. As long as the mod won't suddenly conflict with BG2:EE resources it should be still supported regardless of the chnges done to it. Although let us know if you notice any problems.</p>
 </div>
 
-<!-- ================== NATIVE ================== --><a id="native" name="native"></a>
+<!-- ================== NATIVE ================== --><div><a id="native" name="native"></a></div>
 <h2>Mods installed after EET main component on BG2:EE</h2>
 <div class="section">
 
@@ -259,7 +259,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/D2-mods/Better-IWD-Pregen/releases">Better IWD Pregen - a minimalist script for all classes</a> v0.6 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/bg1npc/">BG1 NPC Project</a> v24.2 and above</li>
 	<li><a href="https://www.gibberlings3.net/files/file/692-bg1-npc-project-music-pack/">BG1 NPC Project Music Pack</a> v6 or above</li>
-	<li><a href="http://www.baldursgatemods.com/forums/index.php?topic=7697.0">BG1 NPCs for SoA & ToB</a> v10 and above</li>
+	<li><a href="http://www.baldursgatemods.com/forums/index.php?topic=7697.0">BG1 NPCs for SoA &amp; ToB</a> v10 and above</li>
 	<li><a href="http://www.shsforums.net/topic/55573-bg-ee-classic-movies/">BG:EE Classic Movies</a> v2.3.0 or above (install after EEUITweaks User Interface Mods Collection)</li>
 	<li><a href="https://github.com/AstroBryGuy/BGEESpawn">BGEE Leveled Spawns Mod</a> v0.4 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/58941/mod-bgeenpc-tweaks-for-bgee-sod-bg2ee-eet/">BGEENPC Tweaks for BGEE / SOD / BG2EE / EET</a> v1.0 or above</li>
@@ -269,7 +269,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/Pocket-Plane-Group/Branwen_for_BGII/releases">Branwen for BG2</a> v4 or above</li>
 	<li><a href="https://github.com/GwendolyneFreddy/butchery">BuTcHeRy</a> v4.0 or above</li>
 	<li><a href="https://www.gibberlings3.net/files/file/1010-calin/">Calin Romance Mod</a> v1.0 or above</li>
-	<li><a href="https://www.gibberlings3.net/mods/spells/celestials/">Celestials (P&P)</a> v7 or above (check for compatibility with other mods)</li>
+	<li><a href="https://www.gibberlings3.net/mods/spells/celestials/">Celestials (P&amp;P)</a> v7 or above (check for compatibility with other mods)</li>
 	<li><a href="https://github.com/SpellholdStudios/CerndFriendship/releases">Cernd Friendship</a> v1.0 or above</li>
 	<li><a href="https://github.com/Argent77/A7-ChaosSorcerer/releases">Chaos Sorcerer Kit</a> v1.0 or above</li>
 	<li><a href="https://github.com/Raduziel/Charlatan-Kit/releases">Charlatan (Bard Kit for PC or Eldoth)</a> v2.0 or above</li>
@@ -414,7 +414,7 @@ a:hover.spoiler {
 	<li><a href="https://downloads.weaselmods.net/download/quayle-bg2/">Quayle BG2</a> v6.2 or above</li>
 	<li><a href="http://www.pocketplane.net/quest">Quest Pack</a> v3.3</li>
 	<li><a href="https://forums.beamdog.com/discussion/71473/megamod-2-86-mazzy-romance-clara-npc-darkside-anomen-flying-aerie-for-the-evil-more/p1">Ratatoskr and BCaesar's Multi-Mod: All Things Mazzy, Clara (Human Hexxat) NPC, Darkside Anomen, and more</a> v1.038 or above</li>
-	<li><a href="http://www.shsforums.net/files/file/1079-recolored-toolbar-buttons-for-bgee-bg2ee/">Recolored toolbar buttons for BG:EE & BG2:EE</a> v4.1 or above</li>
+	<li><a href="http://www.shsforums.net/files/file/1079-recolored-toolbar-buttons-for-bgee-bg2ee/">Recolored toolbar buttons for BG:EE &amp; BG2:EE</a> v4.1 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/77784/v1-37-recorder-a-gnome-lorekeeper-npc-for-bg-ee-sod-and-eet/p1">Recorder NPC</a> v1.37 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/Red_Dragon_Summoning_Spell">Red Dragon Summoning</a> v2.0.0 or above</li>
 	<li><a href="https://github.com/subtledoctor/refinements/releases">Refinements</a> v4 RC8 or above (only HLA and kit components have been updated to work with EE platforms)</li>
@@ -440,11 +440,11 @@ a:hover.spoiler {
 	<li><a href="https://github.com/SpellholdStudios/Shadows_over_Soubar/releases">Shadows Over Soubar</a> v1.14 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/other/shards/">Shards Of Ice</a> v6</li>
 	<li><a href="https://www.gibberlings3.net/forums/topic/32637-lcc-the-shuri-ninja-kit-mod-updated-to-v200/?tab=comments#comment-294145">Shuri Ninja Kit</a> v2.0.0 or above</li>
-	<li><a href="https://www.baldurs-gate.de/index.php?resources/jasteys-sir-ajantis-für-bgii-npc.9/">Sir Ajantis BG2</a> v15.5 or above</li>
+	<li><a href="https://www.baldurs-gate.de/index.php?resources/jasteys-sir-ajantis-f%C3%BCr-bgii-npc.9/">Sir Ajantis BG2</a> v15.5 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/62163/npc-mod-sirene-npc-for-bg2-ee-v1-3-eet-compatibility-added/p1">Sirene NPC for BG2:EE</a> v1.3 or later (should have full continuity if BG:EE version is present)</li>
 	<li><a href="https://downloads.weaselmods.net/download/skie-the-cost-of-one-girls-soul/">Skie - The Cost of One Girl's Soul</a> v1.2 or above (The mod may not be compatible (story-wise) with other mods that add Soultaker and/or Skie plots to Baldur's Gate II)</li>
 	<li><a href="http://www.shsforums.net/files/file/1150-skip-chateau-irenicus/">Skip Chateau Irenicus</a> v1.0 or above</li>
-	<li><a href="http://www.baldursgatemods.com/forums/index.php?topic=7697.0">Smiling Imp's Cross Banter Mod (additional dialogues to the BG1 NPCs for SoA & ToB mod)</a> v1.2 or above</li>
+	<li><a href="http://www.baldursgatemods.com/forums/index.php?topic=7697.0">Smiling Imp's Cross Banter Mod (additional dialogues to the BG1 NPCs for SoA &amp; ToB mod)</a> v1.2 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/items/sod-to-bg2ee-item-upgrade/">SoD to Baldur's Gate 2: Enhanced Edition Item Upgrade</a> v2.0.0 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/Solaufein_Flirt_Pack/releases">Solaufein Flirt Pack for the Solaufein Romance Modification</a> v1.2 or above</li>
 	<li><a href="https://www.baldurs-gate.de/index.php?resources/jasteys-solaufein-npc-mod-for-bgii-solaufeins-rescue.13/">Solaufein's Rescue (Jastey's Solaufein)</a> v1 or above</li>
@@ -515,7 +515,7 @@ a:hover.spoiler {
 	<li><a href="https://github.com/SpellholdStudios/Yeslick_NPC/releases">Yeslick SoA/ToB</a> v2.0 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/YoshimoFriendship/releases">Yoshimo Friendship</a> v4.3 or above</li>
 	<li><a href="https://downloads.weaselmods.net/download/yoshimo-romance/">Yoshimo Romance</a> v4.0 or above</li>
-	<li><a href="http://www.baldursgatemods.com/forums/index.php?topic=7697.0">Zelink (Zelda & Link) mod for Baldur's Gate 2 SoA</a> v1.0 or above</li>
+	<li><a href="http://www.baldursgatemods.com/forums/index.php?topic=7697.0">Zelink (Zelda &amp; Link) mod for Baldur's Gate 2 SoA</a> v1.0 or above</li>
 </ul>
 </div>
 

--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>Mod Compatibility List for EET</title>
-<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-<style type="text/css">/*<![CDATA[*/
-<!--
+<meta charset="UTF-8">
+<style>
 body  {
   font-family: Arial, Helvetica, sans-serif;
   font-size: 1rem;  /* formerly 12px */
@@ -145,8 +144,6 @@ a:hover.spoiler {
   overflow:hidden;
   word-break:normal;
 }
--->
-/*]]>*/
 </style>
 </head>
 <body>
@@ -168,7 +165,7 @@ a:hover.spoiler {
 </ul>
 </div>
 
-<!-- ================== T a b l e ================== --><div><a id="table" name="table"></a></div>
+<!-- ================== T a b l e ================== --><div><a id="table"></a></div>
 <h2>Table of Contents</h2>
 <div class="section">
 	<ol>
@@ -177,7 +174,7 @@ a:hover.spoiler {
 	</ol>
 </div>
 
-<!-- ================== BGEE ================== --><div><a id="bgee" name="bgee"></a></div>
+<!-- ================== BGEE ================== --><div><a id="bgee"></a></div>
 <h2>Mods installed on BG:EE previous to installing EET on BG2:EE</h2>
 <div class="section">
 
@@ -210,7 +207,7 @@ a:hover.spoiler {
 <p>Mods have been tested with versions mentioned in above list. It's unlikely that newer ones will break something, as the compatibility changes made to them during EET installation are minimal, if made at all. As long as the mod won't suddenly conflict with BG2:EE resources it should be still supported regardless of the chnges done to it. Although let us know if you notice any problems.</p>
 </div>
 
-<!-- ================== NATIVE ================== --><div><a id="native" name="native"></a></div>
+<!-- ================== NATIVE ================== --><div><a id="native"></a></div>
 <h2>Mods installed after EET main component on BG2:EE</h2>
 <div class="section">
 


### PR DESCRIPTION
[http://mirandir.baldursgateworld.fr/garrick-tt/](http://mirandir.baldursgateworld.fr/garrick-tt/) is redirected to [http**s**://mirandir.baldursgateworld.fr/garrick-tt/](https://mirandir.baldursgateworld.fr/garrick-tt/) but I didn't update this one because it has cert issues and I didn't want to link to https if they fix the issue by NOT automatically redirecting to https.

Closes #67