### PR TITLE
Add 3.5e Weapon Style Rebalance, Ace's Enchanters Portrait Pack, Amaurea's BG Portraits, Amaurea's BG2 Portraits

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -213,8 +213,10 @@ a:hover.spoiler {
 
 <p>This list, sorted in alphabetical order, contains BG2:EE and BG:EE mods that have native EET support or don't need anything changed to work natively. Some of them are only available as a beta for now (older versions didn't have EET support), so keep that in mind.</p>
 <ul>
+	<li><a href="http://www.shsforums.net/files/download/1205-35-edition-weapon-style-rebalance/">3.5e Weapon Style Rebalance</a></li>
 	<li><a href="https://github.com/UnearthedArcana/5E_spellcasting/releases">5E-Style Spellcasting</a> v1.1 or above</li>
 	<li><a href="http://www.shsforums.net/topic/61094-acs-miscellaneous-tweaks/">AC's Miscellaneous Tweaks</a> RC1 or above</li>
+	<li><a href="https://www.gibberlings3.net/files/file/1007-aces-enchanters-portrait-pack/">Ace's Enchanters Portrait Pack</a></li>
 	<li><a href="https://github.com/Argent77/A7-Achievements/releases">Achievements!</a> v1.0 or above</li>
 	<li><a href="https://www.baldurs-gate.de/index.php?resources/adalons-blood-silberdrachenblutmod.5/">Adalon's Blood</a> v1.4 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/Adrian_NPC/releases">Adrian NPC</a> V4.0 or above</li>
@@ -224,6 +226,8 @@ a:hover.spoiler {
 	<li><a href="http://www.shsforums.net/topic/59054-ajocmod-for-ee-and-eet/">Ajoc's minimod for EE and EET</a> v1.0 or above (this update requires resources from <a href="http://www.shsforums.net/files/file/119-ajocs-minimod/">original ajocmod</a>)</li>
 	<li><a href="http://www.shsforums.net/files/file/1053-almaterias-restoration-project/">Almateria's Restoration Project</a> v8.2.7 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/alternatives/">Alternatives</a> v12 or above</li>
+	<li><a href="https://www.gibberlings3.net/files/file/684-amaureas-bg-portraits/">Amaurea's BG Portraits</a></li>
+	<li><a href="https://www.gibberlings3.net/files/file/683-amaureas-bg2-portraits/">Amaurea's BG2 Portraits</a></li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/amber/">Amber</a> v5 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/angelo/">Angelo NPC</a> v6</li>
 	<li><a href="https://github.com/thisisulb/AnimalCompanions">Animal Companions</a> v1.3 or above</li>


### PR DESCRIPTION
No changelog is available for 3.5e Weapon Style Rebalance to see the exact version that added EET support, possibly there from the start (mentioned in the description of one of the options). The portrait packs mention being compatible with anything except PS:T (or PS: T EE) in their readmes and were also marked compatible in Cahir's list.