### PR TITLE
Remove Convenient Enhanced Edition NPCs duplicate

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -294,7 +294,6 @@ a:hover.spoiler {
 	<li><a href="https://github.com/Pocket-Plane-Group/deArnise_Romance/releases">de'Arnise Romance</a> v6 or above</li>
 	<li><a href="https://www.gibberlings3.net/forums/topic/30780-kit-pack-deities-of-faer%C3%BBn-bgee-bg2ee-iwdee-and-eet/">Deities Of Faerun (Cleric Kits)</a> v1.8.4 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/140-demon-summoning-ritual/">Demon Summoning Ritual</a> v8.0.0 or above</li>
-	<li><a href="http://www.shsforums.net/files/file/1135-disable-enhanced-edition-npcs/">Disable Enhanced Edition NPCs</a> v2.1 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/kits/cleric/">Divine Remix</a> for now, please use <a href="https://github.com/Gibberlings3/Divine_Remix/archive/master.zip">latest Github version</a></li>
 	<li><a href="https://github.com/trinit2/Bg2Dorn/">Dorn Romance (SoA+ToB)</a>v3.2 or above</li>
 	<li><a href="https://github.com/thisisulb/DreamWalkerShamanKit">Dream Walker - a Shaman Kit</a> v1.2 or above</li>


### PR DESCRIPTION
The removed duplicate is Disable Enhanced Edition NPCs, its link now redirects to Convenient Enhanced Edition NPCs on SHS (possibly a rename). Leaving the GitHub link to Convenient Enhanced Edition NPCs, since it's a more stable host.