### PR TITLE
Remove Improved Haer'Dalis Swords duplicate

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -333,7 +333,6 @@ a:hover.spoiler {
 	<li><a href="https://www.gibberlings3.net/mods/npcs/grey-the-dog/">Grey the Dog</a> v1.0 or above</li>
 	<li><a href="https://github.com/SpellholdStudios/HaerdalisFriendship/releases">Haer'Dalis Friendship</a> v1 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/984-haerdalis-romance/">Haer'Dalis Romance</a> v2.2</li>
-	<li><a href="http://www.shsforums.net/files/file/804-haerdalis-swords/">Haer'Dalis Swords</a> v2 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/777-haiass-el-lobo/">Haiass el Lobo</a> v2.4 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/haldamir/">Haldamir NPC</a> v4</li>
 	<li><a href="https://forums.beamdog.com/discussion/76460/v1-48-helga-a-dwarven-priestess-of-haela-brightaxe-for-bg-ee-and-sod-and-eet/p1">Helga NPC</a> v1.48 or above</li>


### PR DESCRIPTION
The links lead to the same mod, the [readme](https://spellholdstudios.github.io/readmes/improved-haerdalis-swords-readme-english.html) has native EET support at v3.0.