### PR TITLE
Remove Multiclassed Multikit Builder Mod duplicate

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -321,7 +321,6 @@ a:hover.spoiler {
 	<li><a href="https://github.com/UnearthedArcana/Faiths_and_Powers/releases">Faiths and Powers (kitpack and divine caster/spell tweaks)</a> v0.74g or above</li>
 	<li><a href="https://github.com/Pocket-Plane-Group/Finch_NPC/releases">Finch NPC mod</a> v5 or above</li>
 	<li><a href="https://github.com/InfinityMods/FishingForTrouble">Fishing For Trouble</a> v3.1 pre-release or above</li>
-	<li><a href="https://github.com/CrevsDaak/m7multikit">FlameWing's Multikit mod</a> v0.27.3</li>
 	<li><a href="https://github.com/Gibberlings3/Forgotten-Armament/releases">Forgotten Armament</a> v0.4-beta or above</li>
 	<li><a href="https://github.com/Gibberlings3/framed/releases">Framed</a> alternative chapter 6</li>
 	<li><a href="https://www.gibberlings3.net/mods/npcs/garrick/">Garrick's Infatuation</a> vBeta 4 or above</li>


### PR DESCRIPTION
The links and compatible version numbers are the same. Leaving the one with the full title, deleting the one titled with a shorthard.