### PR TITLE
Remove The Artisan's Kitpack duplicate

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -408,7 +408,6 @@ a:hover.spoiler {
 	<li><a href="https://github.com/thisisulb/NoSoDSound">NPCs keep BG1 sound sets during SoD</a> v1 or above</li>
 	<li><a href="https://github.com/ArtemiusI/Pai-Na-NPC-mod-for-BG2-EE/releases">Pai'Na NPC for BG2:EE</a> v1.2 or above</li>
 	<li><a href="http://www.shsforums.net/files/file/1032-paintbg-for-bgee/">PaintBG for BG:EE</a> v2.1</li>
-	<li><a href="https://github.com/ArtemiusI/The-Artisan-s-Kitpack">Pale Master Sorcerer Kit</a></li>
 	<li><a href="https://downloads.weaselmods.net/download/petsy/">Petsy Chattertone NPC</a> (since v4.01)</li>
 	<li><a href="https://github.com/SpellholdStudios/Phaere_NPC_Portraits_for_BG2/releases">Phaere NPC Portraits for BG2</a> v5.0 or above</li>
 	<li><a href="https://github.com/4Luke4/PnP-Potions/releases">PnP Potions</a> v1.2.2 or above</li>


### PR DESCRIPTION
The link already led to the pack.