### PR TITLE
Remove The Artisan's Kitpack duplicate

### DIFF
--- a/EET-Compatibility-List.html
+++ b/EET-Compatibility-List.html
@@ -506,7 +506,6 @@ a:hover.spoiler {
 	<li><a href="http://www.shsforums.net/files/file/882-viconia-revamped/">Viconia Revamped</a> v6.0</li>
 	<li><a href="https://forums.beamdog.com/discussion/74701/v1-57-vienxay-a-elven-shadowmage-npc-for-bg-ee-sod-and-eet/p1">Vienxay NPC</a> v1.57 or above</li>
 	<li><a href="https://forums.beamdog.com/discussion/69177/v0-1-warlock-mod/p1">Warlock kit</a></li>
-	<li><a href="https://forums.beamdog.com/discussion/64119/kit-rework-way-of-the-assassin-v1-1/p1">Way of the Assassin</a></li>
 	<li><a href="https://downloads.weaselmods.net/download/weasels/">Weasels!</a> v1.2 or above</li>
 	<li><a href="https://www.gibberlings3.net/mods/quests/wheels/">Wheels of Prophecy</a> v6 or above</li>
 	<li><a href="https://github.com/BGforgeNet/bg2-wildmage">Wild Mage Additions</a> v2.3 beta or above</li>


### PR DESCRIPTION
[The linked forum post](https://forums.beamdog.com/discussion/64119/v1-4-way-of-the-assassin-an-assassin-kit-rework) states that Way of the Assassin has been merged into the Kitpack.